### PR TITLE
Group locations as categories in the menu

### DIFF
--- a/OWER.dot
+++ b/OWER.dot
@@ -3,7 +3,7 @@ digraph G {
 #-----------------------------------------------------
 #Kokiri Forest
 
-KokiriForest[ shape="box", color="forestgreen", label="Kokiri Forest
+KokiriForest[ submenu="Forest", shape="box", color="forestgreen", label="Kokiri Forest
 
 Lost Woods
 LW Bridge
@@ -27,7 +27,7 @@ GS Twins
 
 #-----------------------------------------------------
 #Lost Woods
-LostWoods[shape="box", color="forestgreen", label="Lost Woods
+LostWoods[ submenu="Forest", shape="box", color="forestgreen", label="Lost Woods
 
 River
 Goron
@@ -50,7 +50,7 @@ GS Bean Ride
 
 #-----------------------------------------------------
 #Lost Woods Bridge
-LWBridge[shape="box", color="forestgreen", label="LW Bridge
+LWBridge[ submenu="Forest", shape="box", color="forestgreen", label="LW Bridge
 
 Kokiri Forest
 Field
@@ -62,7 +62,7 @@ LWBridge -> LostWoods [ label = "", arrowhead="none", arrowtail="none" ]
 
 #-----------------------------------------------------
 #Sacred Forest Meadow
-SFMeadow[shape="box", color="forestgreen", label="SF Meadow
+SFMeadow[ submenu="Forest", shape="box", color="forestgreen", label="SF Meadow
 
 Lost Woods
 
@@ -80,7 +80,7 @@ GS
 
 #-----------------------------------------------------
 #Death Mountain Trail
-Trail[ shape="box", color="red", label="Trail
+Trail[ submenu="Death Mountain", shape="box", color="red", label="Trail
 
 Goron
 Kakariko
@@ -104,7 +104,7 @@ GS Hammer x2
 
 #-----------------------------------------------------
 #Death Mountain Crater
-Crater[ shape="box", color="red", label="Crater
+Crater[ submenu="Death Mountain", shape="box", color="red", label="Crater
 
 Goron
 Trail
@@ -126,7 +126,7 @@ GS Crate
 
 #-----------------------------------------------------
 #Goron City
-Goron[ shape="box", color="red", label="Goron
+Goron[ submenu="Death Mountain", shape="box", color="red", label="Goron
 
 Lost Woods
 Trail
@@ -149,7 +149,7 @@ GS Ropes
 
 #-----------------------------------------------------
 #Zoras River
-River[shape="box", color="blue", label="River
+River[ submenu="Zora", shape="box", color="blue", label="River
 
 Field
 Domain
@@ -171,7 +171,7 @@ GS Walls x2
 
 #-----------------------------------------------------
 #Zoras Domain
-Domain[shape="box", color="blue", label="Domain
+Domain[ submenu="Zora", shape="box", color="blue", label="Domain
 
 River
 Fountain
@@ -189,7 +189,7 @@ GS
 
 #-----------------------------------------------------
 #Zoras Fountain
-Fountain[shape="box", color="blue", label="Fountain
+Fountain[ submenu="Zora", shape="box", color="blue", label="Fountain
 
 Domain
 
@@ -209,7 +209,7 @@ GS Strength2
 #-----------------------------------------------------
 #Lake Hylia
 
-Lake[shape="box", color="cyan", label="Lake
+Lake[ submenu="Hyrule", shape="box", color="cyan", label="Lake
 
 Field
 Domain
@@ -235,7 +235,7 @@ Pierre
 
 #-----------------------------------------------------
 #Gerudo Valley
-G Valley[shape="box", color="yellow", label="G Valley
+G Valley[ submenu="Gerudo", shape="box", color="yellow", label="G Valley
 
 Field
 G Fort
@@ -260,7 +260,7 @@ G Valley -> Lake [ label = "" ]
 
 #-----------------------------------------------------
 #Gerudo Fortress
-G Fort[shape="box", color="yellow", label="G Fort
+G Fort[ submenu="Gerudo", shape="box", color="yellow", label="G Fort
 
 G Valley
 H Wasteland
@@ -280,7 +280,7 @@ GS Archery
 
 #-----------------------------------------------------
 #Haunted Wasteland
-H Wasteland[shape="box", color="yellow", label="H Wasteland
+H Wasteland[ submenu="Gerudo", shape="box", color="yellow", label="H Wasteland
 
 D Colossus
 G Fort
@@ -292,7 +292,7 @@ Carpet
 
 #-----------------------------------------------------
 #Desert Colossus
-D Colossus[shape="box", color="yellow", label="D Colossus
+D Colossus[ submenu="Gerudo", shape="box", color="yellow", label="D Colossus
 
 H Wasteland
 
@@ -312,7 +312,7 @@ GS Hill
 #-----------------------------------------------------
 #Hyrule Castle Market
 
-Market[shape="box", color="white", label="Market
+Market[ submenu="Hyrule", shape="box", color="white", label="Market
 
 Street
 Temple
@@ -333,7 +333,7 @@ Richard
 #-----------------------------------------------------
 #Hyrule Castle
 
-Castle[shape="box",  color="white", label="Castle
+Castle[ submenu="Hyrule", shape="box",  color="white", label="Castle
 
 Market
 
@@ -351,7 +351,7 @@ GS Wall
 #-----------------------------------------------------
 #Drawbridge Street
 
-Street[shape="box", color="white", label="Street
+Street[ submenu="Hyrule", shape="box", color="white", label="Street
 
 Market
 Field
@@ -361,7 +361,7 @@ Field
 
 #-----------------------------------------------------
 #Outside Temple of Time
-Temple[shape="box", color="white", label="Temple
+Temple[ submenu="Hyrule", shape="box", color="white", label="Temple
 
 Market
 
@@ -370,7 +370,7 @@ Market
 
 #-----------------------------------------------------
 #Hyrule Field
-Field[ shape="box", color="darkgreen", label="Field
+Field[ submenu="Hyrule", shape="box", color="darkgreen", label="Field
 
 Street
 G Valley
@@ -395,7 +395,7 @@ Song taught by OoT
 
 #-----------------------------------------------------
 #Kakariko Village
-Kakariko[ shape="box", color="orange", label="Kakariko
+Kakariko[ submenu="Kakariko", shape="box", color="orange", label="Kakariko
 
 Trail
 Graveyard
@@ -431,7 +431,7 @@ GS Impas
 
 #-----------------------------------------------------
 #Graveyard
-Graveyard[ shape="box", color="orange", label="Graveyard
+Graveyard[ submenu="Kakariko", shape="box", color="orange", label="Graveyard
 
 Kakariko
 
@@ -453,7 +453,7 @@ GS Wall
 #-----------------------------------------------------
 #Lon Lon Ranch
 
-Ranch[shape="box", color="darkgreen", label="Ranch
+Ranch[ submenu="Hyrule", shape="box", color="darkgreen", label="Ranch
 
 Field
 
@@ -485,7 +485,7 @@ Child [ shape="box", color = "forestgreen",  label="Child
 >exit
 "]
 
-Potion [ shape="box", color = "orange",  label="Potion
+Potion [ submenu="Kakariko", shape="box", color = "orange",  label="Potion
 
 >Front
 >Back
@@ -493,7 +493,7 @@ Potion [ shape="box", color = "orange",  label="Potion
 Shopping
 "]
 
-Dampes [ shape="box", color = "orange",  label="Dampes
+Dampes [ submenu="Kakariko", shape="box", color = "orange",  label="Dampes
 
 >Kakariko
 >Graveyard
@@ -504,32 +504,35 @@ Race 1
 Race 2
 "]
 
-Minuet[ shape="box", color="forestgreen", label="Minuet
+#-----------------------------------------------------
+#Songs
+
+Minuet[ submenu="Songs", shape="box", color="forestgreen", label="Minuet
 
 >exit
 "]
 
-Bolero[ shape="box", color="red", label="Bolero
+Bolero[ submenu="Songs", shape="box", color="red", label="Bolero
 
 >exit
 "]
 
-Serenade[ shape="box", color="cyan", label="Serenade
+Serenade[ submenu="Songs", shape="box", color="cyan", label="Serenade
 
 >exit
 "]
 
-Requiem[ shape="box", color="yellow", label="Requiem
+Requiem[ submenu="Songs", shape="box", color="yellow", label="Requiem
 
 >exit
 "]
 
-Nocturne[ shape="box", color="orange", label="Nocturne
+Nocturne[ submenu="Songs", shape="box", color="orange", label="Nocturne
 
 >exit
 "]
 
-Prelude[ shape="box", color="white", label="Prelude
+Prelude[ submenu="Songs", shape="box", color="white", label="Prelude
 
 >exit
 "]

--- a/rattrack.py
+++ b/rattrack.py
@@ -521,6 +521,7 @@ class TrackerCanvas(Canvas):
 
     def menu(self, event):
         popup = Menu(window, tearoff=0)
+        submenus = dict()
         space = True
 
         clicked = self.svg_get_clicked_thing(event.x, event.y)
@@ -547,10 +548,20 @@ class TrackerCanvas(Canvas):
         if space:
             for n in world.get_node_list():
                 if not n.get_name() in roots and n.get("label") != "\"?\"":
-                    def add_command(name):
-                        popup.add_command(label=interiorss[n.get_name()]["title"], \
-                                          command = lambda : self.add_root(name))
-                    add_command(n.get_name())
+                    def add_command(pop, name):
+                        pop.add_command(label=interiorss[n.get_name()]["title"], \
+                                        command = lambda : self.add_root(name))
+                    sub_name = n.get("submenu")
+                    if sub_name is not None:
+                        # Adds a submenu category
+                        sub_name = sub_name.strip('"')
+                        if sub_name not in submenus:
+                            submenus[sub_name] = Menu(window, tearoff=False)
+                            popup.add_cascade(label=sub_name, menu=submenus[sub_name])
+                        add_command(submenus[sub_name], n.get_name())
+                    else:
+                        # Add normal option to menu.
+                        add_command(popup, n.get_name())
 
         popup.add_separator()
         popup.add_command(label="Zoom In (+)", command = lambda : self.zoom_in())


### PR DESCRIPTION
It's very messy having every single location in the game in one menu, so I thought in grouping them, so they are easier to find.

Screenshots:
![image](https://user-images.githubusercontent.com/7416381/97059563-20bcf000-1567-11eb-970f-f316111ac0c4.png)
![image](https://user-images.githubusercontent.com/7416381/97059609-434f0900-1567-11eb-93a9-49b4dff28a51.png)

Also, if all the locations of a category are selected, that category is no longer displayed:
![image](https://user-images.githubusercontent.com/7416381/97059792-df791000-1567-11eb-9f11-51029959e392.png)
(notice forest is no longer in that menu)
